### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ npm run dev
 npm run build
 ```
 
+## Deployment
+
+The project uses GitHub Pages for hosting. When changes are pushed to `main`,
+an automated workflow builds the site and publishes the `dist` folder to the
+`gh-pages` branch. Configure GitHub Pages to serve from the `gh-pages` branch
+to update [milewska.github.io](https://milewska.github.io).
+
 ## CSV Format
 
 The CSV must include the following headers:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build site and publish to `gh-pages`
- document deployment process in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897c85fac9c83218d1cfe6631cd890b